### PR TITLE
Fixed typo in readme example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,7 +145,7 @@ E.g.
     c.SwarmSpawner.images = [
         {'image': 'jupyter/base-notebook:30f16d52126f',
          'name': 'Minimal python notebook',
-         'placement': {'constraint': ['node.hostname==worker1']}},
+         'placement': {'constraints': ['node.hostname==worker1']}},
     ]
 
 


### PR DESCRIPTION
- placement needs constraints parameter, not constraint
- it is correct in a previous example: https://github.com/ucphhpc/SwarmSpawner/blob/3a8e039167ffe1857bbd11dca8717c2cc9f2b48d/README.rst?plain=1#L115